### PR TITLE
Fix failure on non-matching header

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ module.exports = function preserveCommentHeader(api) {
         if (
           (typeof pattern === "string" &&
             firstComment.value.indexOf(pattern) !== -1) ||
-          pattern.test(firstComment.value)
+          (typeof pattern.test === "function" &&
+            pattern.test(firstComment.value))
         ) {
           path.node.innerComments = path.node.innerComments || [];
 


### PR DESCRIPTION
When a header comment exists, but doesn't match, the
first half of the test condition will fail even if the pattern
is a string. This failure causes the second condition to be
evaluated, which may cause a `TypeError` if the pattern
is not a regular expression.